### PR TITLE
fix: bad typing conversion between enum and long

### DIFF
--- a/json-build.h
+++ b/json-build.h
@@ -327,7 +327,7 @@ jsonb_object_pop(jsonb *b, char buf[], size_t bufsize)
     return code;
 }
 
-static long
+static jsonbcode
 _jsonb_escape(
     size_t *pos, char buf[], size_t bufsize, const char str[], size_t len)
 {

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,5 @@
 TOP = ..
-CC ?= gcc
+CC = cc
 
 EXES = test fuzz
 


### PR DESCRIPTION
Fix bad typing conversion between enum and long

Closes #4